### PR TITLE
add optional sroll callback function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export default function (settings = {}) {
     elements              : [],
     dataLayer             : window.dataLayer,
     trackerName           : '',
+    scrollCallback        : null,
     eventName             : 'CustomEvent',
     eventCategory         : 'Scroll Depth',
     percentageDepthAction : 'Percentage Depth',
@@ -32,6 +33,8 @@ export default function (settings = {}) {
   function send(o) {
     if (settings.dataLayer) {
       settings.dataLayer.push(o)
+    } else if (settings.scrollCallback !== null) {
+      settings.scrollCallback(o)
     } else if (window[window.GoogleAnalyticsObject]) {
       window[window.GoogleAnalyticsObject](`${settings.trackerName}send`, 'event', o.eventCategory, o.eventAction, o.eventLabel, o.eventValue, { nonInteraction: o.nonInteraction })
     }
@@ -79,7 +82,7 @@ export default function (settings = {}) {
 
   /**
    * Return the event label
-   * @param  {node} element
+   * @param  {HTMLElement} element
    * @return {string}
    */
   function formatElementLabel(element) {


### PR DESCRIPTION
Hello, 

I wanted to have more precise control over scroll events, and also, I couldn't control dataLayer object, and setting up Proxy listeners on an array looked like an overkill.

I implemented simple callback, that can be passed during init, and then user can decide what to do with events (for example send it to system other than GA)

```
  // ------------------------------------
  // Scroll handler function
  const scrollHandler = (scrollData) => {
    if (scrollData.eventAction === 'Percentage Depth') {
      const eventData =  {
        scrollPercentage: scrollData.eventLabel,
        url: data.browser.clientInfo.href || 'URL_UNKNOWN',
      };
      sendEventToSomewhere('scroll-depth', eventData);    //send event here
    }
  };
  // ------------------------------------
  // Actual scroll event setup
  scrollDepth({
    throttle: 350,
    scrollElement: document.body,
    sendCallback: scrollHandler,
    percentages: [0.25, 0.5, 0.75, 0.99],
  });

```

also, while there, fixed `{node}` to `{HTMLElement}` for proper definitions in IntelliJ